### PR TITLE
Improve player setup layout

### DIFF
--- a/CricketScorer/Views/PlayerSetupPage.xaml
+++ b/CricketScorer/Views/PlayerSetupPage.xaml
@@ -6,14 +6,14 @@
              BackgroundColor="White">
 
     <ScrollView>
-        <VerticalStackLayout Padding="20" Spacing="20">
+        <VerticalStackLayout Padding="20" Spacing="20" HorizontalOptions="FillAndExpand">
 
             <Label x:Name="TeamALabel" Text="Team A Players" FontAttributes="Bold" FontSize="18" />
-            <VerticalStackLayout x:Name="TeamAPlayersStack" Spacing="10" />
+            <VerticalStackLayout x:Name="TeamAPlayersStack" Spacing="10" HorizontalOptions="FillAndExpand" />
             <Button Text="Add Player to Team A" Clicked="OnAddTeamAPlayerClicked" />
 
             <Label x:Name="TeamBLabel"  Text="Team B Players" FontAttributes="Bold" FontSize="18" />
-            <VerticalStackLayout x:Name="TeamBPlayersStack" Spacing="10" />
+            <VerticalStackLayout x:Name="TeamBPlayersStack" Spacing="10" HorizontalOptions="FillAndExpand" />
             <Button Text="Add Player to Team B" Clicked="OnAddTeamBPlayerClicked" />
 
             <Button Text="Start Match"

--- a/CricketScorer/Views/PlayerSetupPage.xaml.cs
+++ b/CricketScorer/Views/PlayerSetupPage.xaml.cs
@@ -3,6 +3,7 @@ using CricketScorer.Core.Services;
 using CricketScorer.Helpers;
 using CricketScorer.Views;
 using System.Text.RegularExpressions;
+using Microsoft.Maui.Graphics;
 
 namespace CricketScorer;
 
@@ -64,15 +65,40 @@ public partial class PlayerSetupPage : ContentPage
             HorizontalOptions = LayoutOptions.FillAndExpand
         };
 
-        var upButton = new Button { Text = "⬆", FontSize = 20, WidthRequest = 50 };
-        var downButton = new Button { Text = "⬇", FontSize = 20, WidthRequest = 50 };
-        var removeButton = new Button { Text = "❌", TextColor = Colors.Red, FontSize = 20, WidthRequest = 50 };
+        var upButton = new Button
+        {
+            Text = "⬆",
+            FontSize = 16,
+            WidthRequest = 40,
+            BackgroundColor = Color.FromArgb("#4CAF50"),
+            TextColor = Colors.White,
+            CornerRadius = 6
+        };
+        var downButton = new Button
+        {
+            Text = "⬇",
+            FontSize = 16,
+            WidthRequest = 40,
+            BackgroundColor = Color.FromArgb("#2196F3"),
+            TextColor = Colors.White,
+            CornerRadius = 6
+        };
+        var removeButton = new Button
+        {
+            Text = "❌",
+            FontSize = 16,
+            WidthRequest = 40,
+            BackgroundColor = Color.FromArgb("#F44336"),
+            TextColor = Colors.White,
+            CornerRadius = 6
+        };
 
         var container = new HorizontalStackLayout
         {
-            Spacing = 10,
-            Children = { entry, upButton, downButton, removeButton },
-            Padding = new Thickness(0, 5)
+            Spacing = 5,
+            Padding = new Thickness(0, 5),
+            HorizontalOptions = LayoutOptions.FillAndExpand,
+            Children = { entry, upButton, downButton, removeButton }
         };
 
         // Button actions


### PR DESCRIPTION
## Summary
- make player setup page horizontally stretch
- reduce icon button size and add subtle colors

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684729af8654832f838d8a94c61d7100